### PR TITLE
Berechnung und Export des Mitgliederstatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Hitobito KLJB Changelog
+
+## unreleased
+
+* Berechnung und Export der normalen und ermäßigt zahlenden Mitglieder (kljb#4)

--- a/app/domain/groups/member_payment_status.rb
+++ b/app/domain/groups/member_payment_status.rb
@@ -21,11 +21,28 @@ module Groups
     end
 
     def normal_members
-      @normal_members ||= 10
+      @normal_members ||= all_members.count - discounted_members
     end
 
     def discounted_members
-      @discounted_members ||= 0
+      @discounted_members ||= underage_members_with_two_siblings.count
+    end
+
+    private
+
+    def all_members
+      @group.people
+    end
+
+    def members_with_siblings
+      all_members.where.not(family_key: nil).order(:family_key, :birthday)
+    end
+
+    def underage_members_with_two_siblings
+      all_members
+        .group_by(&:family_key)
+        .map { |_key, family| family.drop(2).select(&:underage?) }
+        .flatten.compact
     end
   end
 end

--- a/app/domain/groups/member_payment_status.rb
+++ b/app/domain/groups/member_payment_status.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Katholische Landjugendbewegung Paderborn. This file is part of
+#  hitobito_kljb and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_kljb.
+
+module Groups
+  class MemberPaymentStatus
+    def initialize(group)
+      @group = group
+    end
+
+    def update
+      return false unless @group.layer?
+
+      @group.update(
+        members_normal: normal_members,
+        members_discounted: discounted_members
+      )
+    end
+
+    def normal_members
+      @normal_members ||= 0
+    end
+
+    def discounted_members
+      @discounted_members ||= 0
+    end
+  end
+end

--- a/app/domain/groups/member_payment_status.rb
+++ b/app/domain/groups/member_payment_status.rb
@@ -39,14 +39,24 @@ module Groups
     end
 
     def members_with_siblings
-      all_members_of_layer.where.not(family_key: nil).order(:family_key, :birthday)
+      all_members_of_layer.where.not(family_key: nil).order(:family_key)
     end
 
-    def underage_members_with_two_siblings
-      all_members_of_layer
+    def complete_families(keys)
+      Person.where(family_key: keys).order(:family_key, :birthday)
+    end
+
+    def underage_people_with_two_siblings(keys)
+      complete_families(keys)
         .group_by(&:family_key)
         .map { |_key, family| family.drop(2).select(&:underage?) }
         .flatten.compact
+    end
+
+    def underage_members_with_two_siblings
+      keys = members_with_siblings.uniq.pluck(:family_key)
+
+      underage_people_with_two_siblings(keys) & all_members_of_layer
     end
   end
 end

--- a/app/domain/groups/member_payment_status.rb
+++ b/app/domain/groups/member_payment_status.rb
@@ -21,7 +21,7 @@ module Groups
     end
 
     def normal_members
-      @normal_members ||= 0
+      @normal_members ||= 10
     end
 
     def discounted_members

--- a/app/domain/groups/member_payment_status.rb
+++ b/app/domain/groups/member_payment_status.rb
@@ -64,7 +64,9 @@ module Groups
     def underage_people_with_two_siblings(keys)
       complete_families(keys)
         .group_by(&:family_key)
-        .map { |_key, family| family.drop(2).select(&:underage?) }
+        .map { |_key, family| family.drop(2).select { |person| 
+          person.underage?(Groups::MemberPaymentStatus.cutoff_date)
+        } }
         .flatten.compact
     end
 

--- a/app/domain/groups/member_payment_status.rb
+++ b/app/domain/groups/member_payment_status.rb
@@ -7,6 +7,21 @@
 
 module Groups
   class MemberPaymentStatus
+    AGE_CUTOFF_DATE = [8, 31].freeze
+
+    class << self
+      def cutoff_date
+        now = Date.current
+        year = if now >= Date.new(now.year, *AGE_CUTOFF_DATE)
+                 now.year
+               else
+                 now.year - 1
+               end
+
+        Date.new(year, *AGE_CUTOFF_DATE)
+      end
+    end
+
     def initialize(group)
       @group = group
     end

--- a/app/jobs/member_payment_status_job.rb
+++ b/app/jobs/member_payment_status_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Katholische Landjugendbewegung Paderborn. This file is part of
+#  hitobito_kljb and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_kljb.
+
+class MemberPaymentStatusJob < RecurringJob
+  private
+
+  def perform_internal
+    Group::Ortsgruppe.all.find_each do |group|
+      Groups::MemberPaymentStatus.new(group).update
+    end
+  end
+
+  def next_run
+    Time.new(Time.zone.now.year.succ, 8, 31, 5, 0).in_time_zone
+  end
+end

--- a/app/models/kljb/person.rb
+++ b/app/models/kljb/person.rb
@@ -13,6 +13,6 @@ module Kljb::Person
   end
 
   def underage?
-    years.presence < 18
+    years(Groups::MemberPaymentStatus.cutoff_date).presence < 18
   end
 end

--- a/app/models/kljb/person.rb
+++ b/app/models/kljb/person.rb
@@ -11,4 +11,8 @@ module Kljb::Person
   included do
     Person::PUBLIC_ATTRS -= [:nickname]
   end
+
+  def underage?
+    years.presence < 18
+  end
 end

--- a/app/models/kljb/person.rb
+++ b/app/models/kljb/person.rb
@@ -12,7 +12,9 @@ module Kljb::Person
     Person::PUBLIC_ATTRS -= [:nickname]
   end
 
-  def underage?
-    years(Groups::MemberPaymentStatus.cutoff_date).presence < 18
+  def underage?(cutoff_date = Time.zone.now.to_date)
+    return false unless birthday?
+
+    years(cutoff_date).presence < 18
   end
 end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,4 @@
+if Delayed::Job.table_exists? && !Rails.env.test?
+  # schedule cron jobs here
+  MemberPaymentStatusJob.new.schedule
+end

--- a/config/locales/models.kljb.de.yml
+++ b/config/locales/models.kljb.de.yml
@@ -121,7 +121,7 @@ de:
         one: Kontakt
       group/ortsgruppe_leiterrunde/leiter:
         one: Leiter*in
-        
+
       ### EVENTS
       event/role/teamer:
         one: Teamer*in
@@ -131,3 +131,8 @@ de:
         one: Helfer*in
       event/role/participant:
         one: Teilnehmer*in
+
+    attributes:
+      group:
+        members_normal: normale Mitglieder
+        members_discounted: vergünstigte Mitglieder

--- a/db/migrate/20211211112314_add_member_counts_to_groups.rb
+++ b/db/migrate/20211211112314_add_member_counts_to_groups.rb
@@ -1,0 +1,6 @@
+class AddMemberCountsToGroups < ActiveRecord::Migration[6.1]
+  def change
+    add_column :groups, :members_normal, :integer
+    add_column :groups, :members_discounted, :integer
+  end
+end

--- a/spec/domain/export/csv/groups/list_spec.rb
+++ b/spec/domain/export/csv/groups/list_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Katholische Landjugendbewegung Paderborn. This file is part of
+#  hitobito_kljb and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_kljb.
+
+require 'spec_helper'
+require 'csv'
+
+describe Export::Tabular::Groups::List do
+
+  let(:group) { groups(:nord) }
+
+  let(:list) { group.self_and_descendants.without_deleted.includes(:contact) }
+  let(:data) { described_class.csv(list) }
+  let(:csv) { CSV.parse(data, headers: true, col_sep: Settings.csv.separator) }
+
+  subject { csv }
+
+   its(:headers) do
+     expected = [
+       "Id",
+       "Elterngruppe",
+       "Name",
+       "Kurzname",
+       "Gruppentyp",
+       "Haupt-E-Mail",
+       "Adresse",
+       "PLZ",
+       "Ort",
+       "Land",
+       "Ebene",
+       "Beschreibung",
+       "normale Mitglieder",
+       "vergünstigte Mitglieder"
+     ]
+
+     should match_array expected
+     should eq expected
+   end
+
+   it 'has 4 items' do
+     expect(subject.size).to eq(16)
+   end
+
+   context 'first row' do
+     subject { csv[0] }
+
+     its(['Id']) { should == group.id.to_s }
+     its(['Elterngruppe']) { should == group.parent_id&.to_s }
+     its(['Name']) { should == group.name }
+     its(['Kurzname']) { should == group.short_name }
+     its(['Gruppentyp']) { should == 'Regionalverband' }
+     its(['Haupt-E-Mail']) { should == group.email }
+     its(['Adresse']) { should == group.address }
+     its(['PLZ']) { should == group.zip_code.to_s }
+     its(['Ort']) { should == group.town }
+     its(['Land']) { should == group.country_label }
+     its(['Ebene']) { should == group.id.to_s }
+     its(['normale Mitglieder']) { should be_blank }
+     its(['vergünstigte Mitglieder']) { should be_blank }
+   end
+
+   context 'group with members' do
+     subject { csv.find { |row| row['Name'] == group_with_members.name } }
+     let(:group_with_members) { groups(:paderborn) }
+
+     before do
+       group_with_members.update!(
+         members_normal: 23,
+         members_discounted: 7
+       )
+     end
+
+     its(['Gruppentyp']) { should == 'Ortsgruppe' }
+     its(['normale Mitglieder']) { should == "23" }
+     its(['vergünstigte Mitglieder']) { should == "7" }
+   end
+end

--- a/spec/domain/groups/member_payment_status_spec.rb
+++ b/spec/domain/groups/member_payment_status_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2021, Katholische Landjugendbewegung Paderborn. This file is part of
+#  hitobito_kljb and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_kljb.
+
+require 'spec_helper'
+
+describe Groups::MemberPaymentStatus do
+  subject(:nooper) { described_class.new(non_layer) }
+
+  let(:non_layer) { groups(:paderborn_vorstand)}
+
+  it 'does nothing if group is not a layer' do
+    expect(non_layer).to_not be_layer
+    expect(nooper.update).to be_falsey
+  end
+end

--- a/spec/domain/groups/member_payment_status_spec.rb
+++ b/spec/domain/groups/member_payment_status_spec.rb
@@ -38,6 +38,41 @@ describe Groups::MemberPaymentStatus do
     end
   end
 
+  context 'with a group of only one family of 3 siblings' do
+    before do
+      tom   = Fabricate(:person, birthday: 20.years.ago, nickname: 'tom')
+      olaf  = Fabricate(:person, birthday: 15.years.ago, nickname: 'olaf')
+      peter = Fabricate(:person, birthday: 13.years.ago, nickname: 'peter')
+
+      Fabricate(:family_member, person: tom, other: olaf, kind: 'sibling')
+      Fabricate(:family_member, person: tom, other: peter, kind: 'sibling')
+
+      Fabricate('Group::Ortsgruppe::Mitglied', person: tom, group: group)
+      Fabricate('Group::Ortsgruppe::Mitglied', person: olaf, group: group)
+      Fabricate('Group::Ortsgruppe::Mitglied', person: peter, group: group)
+
+      [tom, olaf, peter].each(&:reload)
+    end
+
+    it 'has 3 members in total' do
+      expect do
+        subject.update
+      end.to change { group.members_normal.to_i + group.members_discounted.to_i }.to(3)
+    end
+
+    it 'the 2 oldest siblings count as normal members' do
+      expect do
+        subject.update
+      end.to change(group, :members_normal).to(2)
+    end
+
+    it 'the 1 youngest siblings counts as discounted member' do
+      expect do
+        subject.update
+      end.to change(group, :members_discounted).to(1)
+    end
+  end
+
   context 'with a group of only one family of 2 siblings' do
     before do
       tom = Fabricate(:person)

--- a/spec/domain/groups/member_payment_status_spec.rb
+++ b/spec/domain/groups/member_payment_status_spec.rb
@@ -37,4 +37,27 @@ describe Groups::MemberPaymentStatus do
         .and change(group, :members_discounted).to(0)
     end
   end
+
+  context 'with a group of only one family of 2 siblings' do
+    before do
+      tom = Fabricate(:person)
+      peter = Fabricate(:person)
+
+      Fabricate(:family_member, person: tom, other: peter, kind: 'sibling')
+
+      Fabricate('Group::Ortsgruppe::Mitglied', person: tom, group: group)
+      Fabricate('Group::Ortsgruppe::Mitglied', person: peter, group: group)
+    end
+
+    it 'has assumptions' do
+      expect(group.people.count).to eq 2
+    end
+
+    it 'all count as normal members' do
+      expect do
+        subject.update
+      end.to change(group, :members_normal).to(2)
+        .and change(group, :members_discounted).to(0)
+    end
+  end
 end

--- a/spec/domain/groups/member_payment_status_spec.rb
+++ b/spec/domain/groups/member_payment_status_spec.rb
@@ -174,4 +174,30 @@ describe Groups::MemberPaymentStatus do
       end.to change(bonn, :members_discounted).to(1)
     end
   end
+
+  describe 'cutoff_date' do
+    it 'is the last day of august' do
+      travel_to '2021-12-14' do
+        expect(described_class.cutoff_date).to eq Date.parse('2021-08-31')
+      end
+    end
+
+    it 'is never in the future' do
+      travel_to '2021-08-30' do
+        expect(described_class.cutoff_date).to eq Date.parse('2020-08-31')
+      end
+    end
+
+    it 'may be today' do
+      travel_to '2021-08-31' do
+        expect(described_class.cutoff_date).to eq Date.parse('2021-08-31')
+      end
+    end
+
+    it 'may be in the past' do
+      travel_to '2021-09-01' do
+        expect(described_class.cutoff_date).to eq Date.parse('2021-08-31')
+      end
+    end
+  end
 end

--- a/spec/domain/groups/member_payment_status_spec.rb
+++ b/spec/domain/groups/member_payment_status_spec.rb
@@ -9,11 +9,32 @@ require 'spec_helper'
 
 describe Groups::MemberPaymentStatus do
   subject(:nooper) { described_class.new(non_layer) }
+  subject(:paderborn_status) { described_class.new(group) }
 
+  let(:group) { groups(:paderborn) }
   let(:non_layer) { groups(:paderborn_vorstand)}
 
   it 'does nothing if group is not a layer' do
     expect(non_layer).to_not be_layer
     expect(nooper.update).to be_falsey
+  end
+
+  context 'with a group that has members without siblings' do
+    before do
+      10.times do
+        Fabricate('Group::Ortsgruppe::Mitglied', group: group)
+      end
+    end
+
+    it 'has assumptions' do
+      expect(group.people.count).to eq 10
+    end
+
+    it 'all member are normal members' do
+      expect do
+        subject.update
+      end.to change(group, :members_normal).to(10)
+        .and change(group, :members_discounted).to(0)
+    end
   end
 end

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -3,17 +3,226 @@
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_kljb.
 
-
 root:
   parent:
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
   lft: 1
-  rgt: 2
-  name: KLGB Paderborn
+  rgt: 50
+  name: KLJB Paderborn
   type: Group::Dioezesanverband
-  email: root@example.net
-  address: Ophovener Str. 79a
-  zip_code: 2843
+  email: buero@kljb-paderborn.de
+  address: Leostraße 21
+  zip_code: 33098
   town: Paderborn
-  layer_group_id: <%= ActiveRecord::FixtureSet.identify(:root) %>
 
-# TODO add more groups
+dioezesanvorstand:
+  parent: root
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+  lft: 6
+  rgt: 7
+  name: Diözesanvorstand
+  type: Group::DioezesanverbandVorstand
+  email: dwight@example.org
+  address: Brahmsweg 25b
+  zip_code: 5385
+  town: Tiaberg
+
+buero:
+  parent: root
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+  lft: 4
+  rgt: 5
+  name: Büro
+  type: Group::DioezesanverbandBuero
+  email: edelmira@example.net
+  address: Straßburger Str. 4
+  zip_code: 6370
+  town: Nord Hennes
+
+ag_4:
+  parent: root
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+  lft: 2
+  rgt: 3
+  name: AG
+  type: Group::DioezesanverbandAg
+  email: vito@example.com
+  address: Hitdorfer Str. 20a
+  zip_code: 7642
+  town: Neu Johann
+
+kontakte_5:
+  parent: root
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:root)%>"
+  lft: 8
+  rgt: 9
+  name: Kontakte
+  type: Group::DioezesanverbandKontakte
+  email: eura.lesch@example.org
+  address: Karl-Marx-Str. 42c
+  zip_code: 7913
+  town: Nord Ibrahimhagen
+
+nord:
+  parent: root
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:nord)%>"
+  lft: 10
+  rgt: 41
+  name: Nord
+  type: Group::Regionalverband
+  address: An der Foobar 23
+  zip_code: 76543
+  town: Hinterfüdlikon
+
+vorstand_7:
+  parent: nord
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:nord)%>"
+  lft: 39
+  rgt: 40
+  name: Vorstand
+  type: Group::RegionalverbandVorstand
+
+ag_8:
+  parent: nord
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:nord)%>"
+  lft: 11
+  rgt: 12
+  name: AG
+  type: Group::RegionalverbandAg
+
+
+kontakte_9:
+  parent: nord
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:nord)%>"
+  lft: 21
+  rgt: 22
+  name: Kontakte
+  type: Group::RegionalverbandKontakte
+
+sued:
+  parent: root
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sued)%>"
+  lft: 42
+  rgt: 49
+  name: Süd
+  type: Group::Regionalverband
+
+vorstand_11:
+  parent: sued
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sued)%>"
+  lft: 47
+  rgt: 48
+  name: Vorstand
+  type: Group::RegionalverbandVorstand
+
+ag_12:
+  parent: sued
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sued)%>"
+  lft: 43
+  rgt: 44
+  name: AG
+  type: Group::RegionalverbandAg
+
+kontakte_13:
+  parent: sued
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:sued)%>"
+  lft: 45
+  rgt: 46
+  name: Kontakte
+  type: Group::RegionalverbandKontakte
+
+paderborn:
+  parent: nord
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:paderborn)%>"
+  lft: 23
+  rgt: 30
+  name: Paderborn
+  type: Group::Ortsgruppe
+
+vorstand_15:
+  parent: paderborn
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:paderborn)%>"
+  lft: 28
+  rgt: 29
+  name: Vorstand
+  type: Group::OrtsgruppeVorstand
+
+kontakte_16:
+  parent: paderborn
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:paderborn)%>"
+  lft: 24
+  rgt: 25
+  name: Kontakte
+  type: Group::OrtsgruppeKontakte
+
+leiterrunde_17:
+  parent: paderborn
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:paderborn)%>"
+  lft: 26
+  rgt: 27
+  name: Leiterrunde
+  type: Group::OrtsgruppeLeiterrunde
+
+bonn:
+  parent: nord
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:bonn)%>"
+  lft: 13
+  rgt: 20
+  name: Bonn
+  type: Group::Ortsgruppe
+
+vorstand_19:
+  parent: bonn
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:bonn)%>"
+  lft: 18
+  rgt: 19
+  name: Vorstand
+  type: Group::OrtsgruppeVorstand
+
+kontakte_20:
+  parent: bonn
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:bonn)%>"
+  lft: 14
+  rgt: 15
+  name: Kontakte
+  type: Group::OrtsgruppeKontakte
+
+leiterrunde_21:
+  parent: bonn
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:bonn)%>"
+  lft: 16
+  rgt: 17
+  name: Leiterrunde
+  type: Group::OrtsgruppeLeiterrunde
+
+st_augustin:
+  parent: nord
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:st_augustin)%>"
+  lft: 31
+  rgt: 38
+  name: St. Augustin
+  type: Group::Ortsgruppe
+
+vorstand_23:
+  parent: st_augustin
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:st_augustin)%>"
+  lft: 36
+  rgt: 37
+  name: Vorstand
+  type: Group::OrtsgruppeVorstand
+
+kontakte_24:
+  parent: st_augustin
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:st_augustin)%>"
+  lft: 32
+  rgt: 33
+  name: Kontakte
+  type: Group::OrtsgruppeKontakte
+
+leiterrunde_25:
+  parent: st_augustin
+  layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:st_augustin)%>"
+  lft: 34
+  rgt: 35
+  name: Leiterrunde
+  type: Group::OrtsgruppeLeiterrunde

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -139,7 +139,7 @@ paderborn:
   name: Paderborn
   type: Group::Ortsgruppe
 
-vorstand_15:
+paderborn_vorstand:
   parent: paderborn
   layer_group_id: "<%=ActiveRecord::FixtureSet.identify(:paderborn)%>"
   lft: 28


### PR DESCRIPTION
Fixes #4 

Ich habe mich bemüht, sinnvolle Commits zu machen, allerdings habe ich erst die fertige Domain-Klasse schrittweise committed. Dadurch wirkt es so, als wäre von Anfang an alles perfekt geplant. War es nicht, RSpec hat geholfen.

Neben der Domain-Klasse ist ein Job hinzugekommen und der Export angepasst. Da hier aber schon durch den Core alles gemacht ist, ist nur eine Spec als Beweis dabei.

Für die Domainklasse habe ich noch im Core einen PR, https://github.com/hitobito/hitobito/pull/1548. 
Merge-Reihenfolge: Core, Wagon.
Dummerweise laufen die Specs nicht ohne den Core-PR. "works on my machine..."